### PR TITLE
ispdy: close connection on dealloc

### DIFF
--- a/src/ispdy.m
+++ b/src/ispdy.m
@@ -224,6 +224,10 @@ typedef enum {
 
 
 - (void) dealloc {
+  // Ensure that socket will be removed from the loop and we won't
+  // get any further events on it
+  [self close];
+
   delegate_queue_ = NULL;
   connection_queue_ = NULL;
 }
@@ -366,7 +370,7 @@ typedef enum {
   if (in_stream_ == nil || out_stream_ == nil)
     return NO;
 
-  [self _connectionDispatch: ^{
+  [self _connectionDispatchSync: ^{
     if (goaway_timeout_ != NULL)
       dispatch_source_cancel(goaway_timeout_);
     if (connection_timeout_ != NULL)


### PR DESCRIPTION
Possibly fix following crash:

```
  objc_msgSend + 5
  _CFStreamSignalEvent + 170
  CoreWriteStreamCFStreamSupport::coreStreamWriteEvent(
      __CoreWriteStream*,
      unsigned long) + 74
  CoreWriteStreamClient::coreStreamEventsAvailable(unsigned long) + 36
  CoreStreamBase::_callClientNow(CoreStreamClient*) + 42
  CoreStreamBase::_streamSetEventAndScheduleDelivery(unsigned long,
                                                     unsigned char) + 122
  CoreStreamBase::_streamInterface_SignalEvent(unsigned long,
                                               CFStreamError const*) + 34
  SocketStream::socketCallback(__CFSocket*,
                               unsigned long,
                               __CFData const*,
                               void const*) + 144
  SocketStream::_SocketCallBack_stream(__CFSocket*,
                                       unsigned long,
                                       __CFData const*,
                                       void const*,
                                       void*) + 58
  __CFSocketPerformV0 + 578
  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
  __CFRunLoopDoSources0 + 206
  __CFRunLoopRun + 622
  CFRunLoopRunSpecific + 522
  CFRunLoopRunInMode + 106
  -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 254
  -[NSRunLoop(NSRunLoop) run] + 80
  -[ISpdyLoop main] + 258
  __NSThread__main__ + 1062
  _pthread_body + 140
  _pthread_start + 102
```

/cc @georgekola 
