### PR TITLE
Bumped up the timer interval from 0 to the initial interval

### DIFF
--- a/src/ispdy.m
+++ b/src/ispdy.m
@@ -569,10 +569,12 @@ typedef enum {
                                                    connection_queue_);
   NSAssert(timer, @"Failed to create dispatch timer source");
 
+  uint64_t intervalNS = (uint64_t) (interval * 1e9);
+  uint64_t leeway = (intervalNS>>2) < 100000ULL ? (intervalNS>>2) : 100000ULL;
   dispatch_source_set_timer(timer,
-                            dispatch_walltime(NULL, (int64_t) interval * 1e9),
-                            0,
-                            0);
+                            dispatch_walltime(NULL, intervalNS),
+                            intervalNS,
+                            leeway);
   dispatch_source_set_event_handler(timer, block);
   dispatch_resume(timer);
 


### PR DESCRIPTION
Found while debugging with Ryan on iOS app that timer with interval of 0 fires non-stop. Since we want a one shot timer here, I just set the interval to fire equal to the required first fire interval to ensure that timer does not fire before we cancel it. We also set the leeway to MIN(100ms, timer_interval/4) to conserve battery life. 
