### PR TITLE
setNoDelay shoould correcly allow enable/disable

### DIFF
--- a/src/ispdy.m
+++ b/src/ispdy.m
@@ -652,7 +652,7 @@ typedef enum {
 
   // If stream is not open yet, queue setting option
   if (status != NSStreamStatusOpen && status != NSStreamStatusWriting) {
-    no_delay_ = YES;
+    no_delay_ = enable;
     return;
   }
 


### PR DESCRIPTION
This fixes a bug where if the stream was not open, calling setNoDelay
with disable would actually enable it.

@indutny please review and merge