### PR TITLE
Updates to pod file

### DIFF
--- a/ISpdy.podspec
+++ b/ISpdy.podspec
@@ -22,9 +22,9 @@ Pod::Spec.new do |s|
 
 
 
-  s.frameworks = 'CoreServices', 'Security'
+  s.frameworks = 'CoreFoundation', 'Security'
 
-  s.library   = 'libz'
+  s.libraries   = 'z'
 
   s.requires_arc = true
 


### PR DESCRIPTION
Hi Everyone!  

Let me know if this isn't good procedure, but I wanted to update the podspec. 

Only two updates.

1. Cocoapods tries to be smart when integrating libraries so you don't use the lib prefix in the `spec.library` call
2. `CoreServices` wasn't a found framework. I put in `CoreFoundation` instead. I see now there is a `MobileCoreServices` framework so I'd be happy to change it to that if that is the new replacement for the old `CoreServices` framework.