### PR TITLE
Fixed the last 6 warnings, enabled "Treat warnings as errors"

### DIFF
--- a/ISpdy.podspec
+++ b/ISpdy.podspec
@@ -1,13 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "ISpdy"
-  s.version      = "0.1.0"
+  s.version      = "0.1.1"
   s.summary      = "Spdy client for macosx and iphoneos."
 
   s.homepage     = "https://github.com/Voxer/ispdy"
 
-
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
-
 
   s.author       = { "Fedor Indutny" => "fedor.indutny@gmail.com" }
 
@@ -20,12 +18,14 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'include/*.h'
 
-
-
   s.frameworks = 'Security'
 
   s.library   = 'z'
 
   s.requires_arc = true
+
+  s.xcconfig = {
+    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES'
+  }
 
 end

--- a/include/ispdy.h
+++ b/include/ispdy.h
@@ -41,7 +41,7 @@ typedef enum {
 /**
  * Possible error codes in NSError with domain @"spdy"
  */
-typedef enum {
+typedef NS_ENUM(NSInteger, ISpdyErrorCode) {
   kISpdyErrConnectionTimeout,
   kISpdyErrConnectionEnd,
   kISpdyErrRequestTimeout,
@@ -56,7 +56,7 @@ typedef enum {
   kISpdyErrGoawayError,
   kISpdyErrSendAfterGoawayError,
   kISpdyErrSendAfterClose
-} ISpdyErrorCode;
+};
 
 /**
  * Possible connection states
@@ -103,7 +103,7 @@ typedef void (^ISpdyPingCallback)(ISpdyPingStatus status, NSTimeInterval rtt);
 
 @interface ISpdyError : NSError
 
-- (ISpdyErrorCode) code;
+@property(readonly) ISpdyErrorCode code;
 - (NSString*) description;
 
 /**

--- a/ispdy-iphoneos.xcodeproj/project.pbxproj
+++ b/ispdy-iphoneos.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0FFAA6C91BBD143600CEF619 /* ISpdy.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ISpdy.podspec; sourceTree = "<group>"; };
 		33DFEE9ACE47E7C730EA8CD2 /* parser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = parser.m; sourceTree = "<group>"; };
 		45E89AE67B8AE6EF4718D7C3 /* common.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = common.m; sourceTree = "<group>"; };
 		4E0EC184FCD7551AB66886F7 /* loop.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = loop.m; sourceTree = "<group>"; };
@@ -45,6 +46,7 @@
 		09D72A3446683184C3DA8B19 = {
 			isa = PBXGroup;
 			children = (
+				0FFAA6C91BBD143600CEF619 /* ISpdy.podspec */,
 				76A0499926D35BC73B27804E /* Source */,
 				89F1B268A8AE1DB046DF10EA /* Products */,
 				DC9A387065BBBB1DAFC5D681 /* Build */,
@@ -113,7 +115,11 @@
 			};
 			buildConfigurationList = 97733FC07CD992A00FB661F2 /* Build configuration list for PBXProject "ispdy-iphoneos" */;
 			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 09D72A3446683184C3DA8B19;
 			projectDirPath = "";
 			projectRoot = "";
@@ -145,6 +151,7 @@
 		259C6554D53D5A98ABDAD2D8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INTERMEDIATE_DIR = "$(PROJECT_DERIVED_FILE_DIR)/$(CONFIGURATION)";
 				SHARED_INTERMEDIATE_DIR = "$(SYMROOT)/DerivedSources/$(CONFIGURATION)";
 			};
@@ -153,6 +160,7 @@
 		5459E02B5E6D0632E756BE8A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INTERMEDIATE_DIR = "$(PROJECT_DERIVED_FILE_DIR)/$(CONFIGURATION)";
 				SHARED_INTERMEDIATE_DIR = "$(SYMROOT)/DerivedSources/$(CONFIGURATION)";
 			};

--- a/src/common.m
+++ b/src/common.m
@@ -181,8 +181,8 @@
     case kISpdyErrSendAfterClose:
       return @"ISpdy error: request sent after close";
     default:
-      return [NSString stringWithFormat: @"Unexpected spdy error %d",
-          self.code];
+      return [NSString stringWithFormat: @"Unexpected spdy error %ld",
+          (long)self.code];
   }
 }
 

--- a/src/ispdy.m
+++ b/src/ispdy.m
@@ -746,11 +746,12 @@ static void ispdy_close_source_cb(void* arg) {
 }
 
 
-- (void) _closeSocket {
+- (BOOL) _closeSocket {
   [in_stream_ close];
   [out_stream_ close];
   in_stream_ = nil;
   out_stream_ = nil;
+  return YES;
 }
 
 
@@ -1043,7 +1044,7 @@ static void ispdy_close_source_cb(void* arg) {
       // Partial write
       if (size > (NSUInteger) r) {
         [buffer_size_ replaceObjectAtIndex: 0
-                   withObject: [NSNumber numberWithUnsignedInt: size - r]];
+                   withObject: [NSNumber numberWithUnsignedInteger: size - r]];
         r = 0;
         break;
       }

--- a/src/loop.m
+++ b/src/loop.m
@@ -58,8 +58,8 @@ static dispatch_once_t loop_once;
     // Create timer that fires in distant future, just to keep loop running
     NSTimer* timer = [[NSTimer alloc] initWithFireDate: [NSDate distantFuture]
                                               interval: 0.0
-                                                target: nil
-                                              selector: nil
+                                                target: self
+                                              selector: @selector(dummyTimerFunc:)
                                               userInfo: nil
                                                repeats: NO];
     runLoop_ = [NSRunLoop currentRunLoop];
@@ -77,5 +77,7 @@ static dispatch_once_t loop_once;
     dispatch_semaphore_wait(init_sem_, DISPATCH_TIME_FOREVER);
   return (NSRunLoop *)runLoop_;
 }
+
+- (void)dummyTimerFunc: (NSTimer*)timer{}
 
 @end

--- a/src/request.m
+++ b/src/request.m
@@ -295,8 +295,11 @@ static const NSTimeInterval kResponseTimeout = 60.0;  // 1 minute
       window_out_queue_ = [NSMutableArray arrayWithCapacity: 16];
 
     // Retry on positive window_out
+    __weak __typeof(self) weakSelf = self;
     [window_out_queue_ addObject: ^() {
-      [self _updateWindow: delta withBlock: block];
+      __strong __typeof(self) strongSelf = weakSelf;
+      if(!strongSelf) return;
+      [strongSelf _updateWindow: delta withBlock: block];
     }];
     return;
   }


### PR DESCRIPTION
- Fixed incompatible code property of ISpdyError with the base class NSError: replaced the getter declaration by a property one, using NS_ENUM to make ISpdyErrorCode compatible with NSInteger (the type of NSError's code property), and updated a format string due to this change (common.m:185)
- Fixed _closeSocket declaration and implementation differing in return type
- Fixed an integer precision warning (ispdy.m:1047)
- Fixed the null argument passed to non-null parameter warning in loop.m, added for this a dummy timer method and passing that to the timer
- Fixed retain cycle warning by using weak reference to self in request.m
- Updated the project file and the podspec to enable the "Treat warnings as errors" build setting
